### PR TITLE
install kvtree_mpi.h when using MPI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,9 @@ LIST(APPEND libkvtree_install_headers
 	kvtree.h
     kvtree_util.h
 )
+IF(MPI)
+        LIST(APPEND libkvtree_install_headers kvtree_mpi.h)
+ENDIF(MPI)
 INSTALL(FILES ${libkvtree_install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 LIST(APPEND libkvtree_srcs


### PR DESCRIPTION
Update CMakeLists.txt to also install kvtree_mpi.h when configured to build with MPI support.